### PR TITLE
Adapt dependencies to allow concat 2.2 version

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,6 @@ fixtures:
       ref:  '4.2.2'
     concat:
       repo: 'puppetlabs-concat'
-      ref:  '1.1.1'
+      ref:  '2.2.0'
   symlinks:
     kerberos: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -28,6 +28,6 @@
    ],
   "dependencies": [
     { "name": "puppetlabs/stdlib",  "version_requirement": ">=4.2.0 <5.0.0" },
-    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.0 <2.0.0" }
+    { "name": "puppetlabs/concat", "version_requirement": ">=1.1.0 <3.0.0" }
   ] 
 }


### PR DESCRIPTION
Hi,

I would be interested in using your module to configure kerberos.
Unfortunately, due to old dependencies to puppetlabs-concat it's not easy.

I've run the spec test against puppetlabs-concat version 2.2.0 and it runs like a charm.

Would you accept this dummy PR please ?

Regards,