### PR TITLE
Fix variable reference for dns_lookup_realm.

### DIFF
--- a/templates/krb5.conf.fragments/libdefaults.erb
+++ b/templates/krb5.conf.fragments/libdefaults.erb
@@ -8,7 +8,7 @@
   forwardable      = <%= @forwardable %>
   proxiable        = <%= @proxiable %>
   rdns             = <%= @rdns %>
-  dns_lookup_realm = <%= @dns_lookup_kdc %>
+  dns_lookup_realm = <%= @dns_lookup_realm %>
   dns_lookup_kdc   = <%= @dns_lookup_kdc %>
   <%- if @ticket_lifetime -%>
   ticket_lifetime  = <%= @ticket_lifedime %>


### PR DESCRIPTION
This fixes an issue with the libdefaults fragment where it was using dns_lookup_kdc for both dns_lookup_* settings, rather than using dns_lookup_realm for dns_lookup_realm.  =)