### PR TITLE
Added support for includedir_path (disabled by default).

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ This specifies a custom package or array of packages. The default is the standar
 
 Specifies the location of the Kerberos configuration file. The default is `/etc/krb5.conf`. Setting this parameter is not recommended, but included to support custom packages.
 
+#### `includedir_path`
+
+Specifies a directory that contains arbitrary configuration files to be loaded.  This is disabled by default, but can be enabled for custom settings that the module does not handle.  (ex: appdefaults)  Using this parameter is not recommended unless you have a specific use case.
+
 #### `default_realm`
 
 This sets the default realm for any domain that does not have a specific domain to realm mapping. The default value is `LOCAL`.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -79,7 +79,7 @@ class kerberos (
   if $includedir_path != undef {
     concat::fragment{'krb5_includedir':
       target  => 'krb5_config',
-      content => "includedir ${includedir_path}\n\n",
+      content => "\nincludedir ${includedir_path}\n\n",
       order   => '00001',
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,6 +7,7 @@ class kerberos (
   $ensure           = 'present',
   $package          = $::kerberos::params::package,
   $config_file      = $::kerberos::params::config_file,
+  $includedir_path  = $::kerberos::params::includedir_path,
   $default_realm    = $::kerberos::params::default_realm,
   $dns_lookup_realm = false,
   $dns_lookup_kdc   = false,
@@ -73,6 +74,21 @@ class kerberos (
     group          => 'root',
     mode           => '0644',
     require        => Package[$package]
+  }
+
+  if $includedir_path != undef {
+    concat::fragment{'krb5_includedir':
+      target  => 'krb5_config',
+      content => "includedir ${includedir_path}\n\n",
+      order   => '00001',
+    }
+
+    file { $includedir_path:
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+    }
   }
 
   concat::fragment{'krb5_libdefaults':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,10 +6,11 @@
 class kerberos::params {
 
 # Common values
-  $config_file   = '/etc/krb5.conf'
-  $default_realm = 'LOCAL'
-  $krb4_config   = '/etc/krb.conf'
-  $krb4_realms   = '/etc/krb.realms'
+  $config_file     = '/etc/krb5.conf'
+  $default_realm   = 'LOCAL'
+  $krb4_config     = '/etc/krb.conf'
+  $krb4_realms     = '/etc/krb.realms'
+  $includedir_path = undef
 
 # OS specific values
   case $::osfamily {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -176,6 +176,16 @@ describe 'kerberos', :type => :class do
         %r{^  rdns          = false$}
       ) }
     end
+    describe 'when using an includedir' do
+      let :params do
+        {
+          :includedir_path => '/etc/krb5.conf.d/',
+        }
+      end
+      it { should contain_concat__fragment('krb5_includedir').with_content(
+        %r{^includedir_path /etc/krb5.conf.d$}
+      ) }
+    end
     describe 'when customising the login settings' do
       let :params do
         {


### PR DESCRIPTION
This PR adds support for includedir, which is in a lot of the krb5 default configs these days.  Now, you might be asking.. why?  Well, we have a semi bizarre section in our krb5.conf called appdefaults -- where settings for pam are placed.  It looks something like this:


```
[appdefaults]
 pam = {
   debug = false
   ticket_lifetime = 50400
   renew_lifetime = 50400
   forwardable = true
   krb4_convert = false
   krb4_convert_524 = false
   krb4_use_as_req = false
   minimum_uid = 1
   afs_cells = first.example.org=afs/first.example.org@EXAMPLE.ORG second.example.org=afs/second.example.org@EXAMPLE.ORG third.example.org=afs/third.example.org@EXAMPLE.ORG
 }
```

Trying to account for anything that could possibly show up in that second seemed like an exercise in irritation, so I opted to go the route of "let folk enable includedir" and dump whatever they want in place.

I turned it off by default because while I checked Ubuntu, RHEL6, and RHEL 7, I have no idea how wide the support for includedir is and, really, most folk will want the module managing the -entire- config anyway. =)