### PR TITLE
Remove requirement to specify kdc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ kerberos::realm{'example.org':
 }
 ```
 
+If you have `dns_lookup_kdc` enabled, you do not have to specify a `kdc`.
+
+```puppet
+kerberos::realm{'example.org':
+}
+
 ### Parameters
 
 #### `kdc`

--- a/manifests/realm.pp
+++ b/manifests/realm.pp
@@ -1,6 +1,6 @@
 # Adds a realm definition to krb5.conf
 define kerberos::realm (
-  $kdc,
+  $kdc            = undef,
   $admin_server   = undef,
   $master_kdc     = undef,
   $default_domain = undef,

--- a/templates/krb5.conf.fragments/realm_entry.erb
+++ b/templates/krb5.conf.fragments/realm_entry.erb
@@ -1,11 +1,13 @@
 
   <%= @upcase_name %> = {
-    <%- if @kdc.kind_of?(Array) -%>
-      <%- Array(@kdc).each do |server| -%>
-    kdc            = <%= server %>
+    <%- if @kdc -%>
+      <%- if @kdc.kind_of?(Array) -%>
+        <%- Array(@kdc).each do |server| -%>
+      kdc            = <%= server %>
+        <%- end -%>
+      <%- else -%>
+      kdc            = <%= @kdc %>
       <%- end -%>
-    <%- else -%>
-    kdc            = <%= @kdc %>
     <%- end -%>
     <%- if @master_kdc -%>
     master_kdc     = <%= @master_kdc %>


### PR DESCRIPTION
If someone has dns_lookup_kdc enabled, they don't actually need to include a kdc in their realm config.  This patch allows kdc to be left off of the realm configs.  Probably there should be a check to make sure dns_lookup_kdc is actually turned on before allowing it to be undef but I was in a hurry when I built this.  =)