### PR TITLE
Remove missing (deprecated?) concat force parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,6 @@ class kerberos (
     ensure         => $concat_ensure,
     path           => $config_file,
     warn           => '# This file is managed by Puppet, changes may be overwritten.',
-    force          => true,
     ensure_newline => false,
     owner          => 'root',
     group          => 'root',


### PR DESCRIPTION
Force parameter doesn't exist on concat anymore, and it produces the following error:

```
Puppet Server Error: Evaluation Error: Error while evaluating a Resource Statement, Concat[krb5_config]: has no parameter named 'force' at /etc/puppetlabs/code/environments/.../modules/kerberos/manifests/init.pp:66
```